### PR TITLE
Fix property name

### DIFF
--- a/src/components/Episode.jsx
+++ b/src/components/Episode.jsx
@@ -8,7 +8,7 @@ class Episode extends Component {
   }
   render() {
     return (
-      <div class="list-group" style={this.divStyles}>
+      <div className="list-group" style={this.divStyles}>
         <a href={this.props.link} className="list-group-item list-group-item-action text-left">{this.props.title}</a>
       </div>
     );


### PR DESCRIPTION
This error was printed on console after the episode list is populated:
`Invalid DOM property 'class'. Did you mean 'className'?`

This commit changes Episode.jsx to use the appropriated property name.