### PR TITLE
Fix class name

### DIFF
--- a/src/components/Episode.jsx
+++ b/src/components/Episode.jsx
@@ -4,7 +4,7 @@ class Episode extends Component {
   divStyles = {
     width: "77vw",
     float: "right",
-    "margin-right": "1vw"
+    marginRight: "1vw"
   }
   render() {
     return (


### PR DESCRIPTION
This error is printed after the episode list is populated: `Unsupported style property margin-right. Did you mean marginRight?`

Since `margin-right` is not a valid CSS class, this commit renames it to `marginRight` in order to make it compatible with React.